### PR TITLE
add firstLineMatch for HTML Jinja Templates

### DIFF
--- a/Syntaxes/HTML (Jinja Templates).tmLanguage
+++ b/Syntaxes/HTML (Jinja Templates).tmLanguage
@@ -4,6 +4,8 @@
 <dict>
 	<key>fileTypes</key>
 	<array/>
+	<key>firstLineMatch</key>
+	<string>^{% extends ["'][^"']+["'] %}</string>
 	<key>foldingStartMarker</key>
 	<string>(&lt;(?i:(head|table|tr|div|style|script|ul|ol|form|dl))\b.*?&gt;|{%\s*(block|filter|for|if|macro|raw))</string>
 	<key>foldingStopMarker</key>


### PR DESCRIPTION
Attempt to auto-detect HTML Jinja Templates by checking if the file uses the `extends` tag.
