### PR TITLE
Register filetype .j2 for e.g. IntelliJ (issue #9)

### DIFF
--- a/Syntaxes/Jinja Templates.tmLanguage
+++ b/Syntaxes/Jinja Templates.tmLanguage
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>fileTypes</key>
-	<array/>
+    <array>
+        <string>j2</string>
+    </array>
 	<key>foldingStartMarker</key>
 	<string>({%\s*(block|filter|for|if|macro|raw))</string>
 	<key>foldingStopMarker</key>


### PR DESCRIPTION
This PR registers *.j2 files with the bundle, based on the comment by @FractalizeR in issue https://github.com/mitsuhiko/jinja2-tmbundle/issues/9 . This enables the bundle work in IntelliJ, PyCharm, etc. 